### PR TITLE
Citrix Specific Fixes

### DIFF
--- a/Citrix-low-risk.sh
+++ b/Citrix-low-risk.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# cis_lowrisk_fix.sh — Remediate low‐risk CIS findings
+
+set -euo pipefail
+
+echo "1) Remove unnecessary packages (low-risk cleanup)…"
+for pkg in setroubleshoot-server telnet openldap-clients ypbind tftp; do
+  if rpm -q "$pkg" &>/dev/null; then
+    echo " → Removing $pkg"
+    dnf -y remove "$pkg"
+  else
+    echo " → $pkg not installed"
+  fi
+done
+
+echo
+echo "2) Enforce core dump pattern (no impact on VDA)…"
+sysctl -w kernel.core_pattern="|/bin/false"
+mkdir -p /etc/sysctl.d
+if grep -q '^kernel.core_pattern' /etc/sysctl.d/99-cis.conf; then
+  sed -i 's|^kernel.core_pattern.*|kernel.core_pattern = |/bin/false|' /etc/sysctl.d/99-cis.conf
+else
+  echo 'kernel.core_pattern = |/bin/false' >> /etc/sysctl.d/99-cis.conf
+fi
+sysctl --system
+
+echo
+echo "3) Disable GDM autorun (harmless for VDA)…"
+if grep -q 'autorun-never' /etc/gdm/custom.conf; then
+  echo " → GDM autorun-never already set"
+else
+  echo " → Setting GDM autorun-never"
+  mkdir -p /etc/gdm
+  echo '[daemon]' >> /etc/gdm/custom.conf
+  echo 'AutomaticLoginEnable=false' >> /etc/gdm/custom.conf
+  echo 'AutomaticLogin=' >> /etc/gdm/custom.conf
+  echo 'DefaultSession=gnome' >> /etc/gdm/custom.conf
+  echo 'WaylandEnable=false' >> /etc/gdm/custom.conf
+  echo 'Autorun-Never=true' >> /etc/gdm/custom.conf
+fi
+
+echo
+echo "4) Ensure cron.allow & at.allow contain only root…"
+for file in /etc/cron.allow /etc/at.allow; do
+  echo " → Ensuring $file exists and contains only root"
+  echo root > "$file"
+  chmod 600 "$file"
+done
+
+echo
+echo "5) Ensure cron.deny & at.deny are empty or absent…"
+for file in /etc/cron.deny /etc/at.deny; do
+  if [ -f "$file" ]; then
+    echo " → Truncating $file"
+    : > "$file"
+    chmod 644 "$file"
+  else
+    echo " → $file not present, OK"
+  fi
+done
+
+echo
+echo "6) Confirm chrony runs as root only (low-risk)…"
+# This check is purely informational; chronyd already runs as chrony user by default.
+grep -q '^OPTIONS=.*-u chrony' /usr/lib/systemd/system/chronyd.service \
+  && echo " → chronyd is running as non-root (chrony user)" \
+  || echo " → chronyd service file needs review for user directive"
+
+echo
+echo "Low-risk remediation complete.  You can re-run your verification now."

--- a/Citrix-med-risk.sh
+++ b/Citrix-med-risk.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# cis_citrix_medium_risk.sh — Medium-Risk CIS Remediations for Citrix VDA (SELinux step removed)
+
+set -euo pipefail
+
+echo "=== Medium-Risk Remediation for Citrix VDA ==="
+
+# 1. LDAP client: reinstall if your FAS/LDAP backend needs it
+echo -n "1) Ensuring LDAP client present… "
+if ! rpm -q openldap-clients &>/dev/null; then
+  dnf -y install openldap-clients
+  echo "installed"
+else
+  echo "already present"
+fi
+
+# 2. PAM faillock scoping: skip system/service accounts
+echo -n "2) Scoping pam_faillock to non-root/service UIDs… "
+for f in /etc/pam.d/system-auth /etc/pam.d/password-auth; do
+  if grep -q 'pam_faillock.so' "$f"; then
+    sed -i.bak -E "/pam_faillock\\.so preauth/ i auth [success=1 default=ignore] pam_succeed_if.so uid > 0 quiet" "$f"
+    sed -i -E "/pam_faillock\\.so authfail/ i auth [success=1 default=ignore] pam_succeed_if.so uid > 0 quiet" "$f"
+  fi
+done
+echo "done"
+
+# 3. SSH KexAlgorithms: apply Citrix-recommended list
+echo -n "3) Hardening SSH KexAlgorithms… "
+SSH_CONF=/etc/ssh/sshd_config
+grep -q '^KexAlgorithms ' "$SSH_CONF" \
+  && sed -i.bak -E "s|^KexAlgorithms.*|KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group14-sha1|" "$SSH_CONF" \
+  || echo "KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group14-sha1" >> "$SSH_CONF"
+systemctl reload sshd
+echo "done"
+
+# 4. Trust loopback in the firewall
+echo -n "4) Trusting loopback interface… "
+if command -v firewall-cmd &>/dev/null; then
+  firewall-cmd --permanent --zone=trusted --add-interface=lo
+  firewall-cmd --reload
+else
+  nft list ruleset | grep -q 'iif lo accept' || nft insert rule inet filter input iif lo accept
+fi
+echo "done"
+
+# 5. Blacklist usb-storage (if acceptable for your USB policy)
+echo -n "5) Blacklisting usb-storage… "
+BL=/etc/modprobe.d/usb-blacklist.conf
+if ! grep -q 'blacklist usb-storage' "$BL" 2>/dev/null; then
+  echo -e "install usb-storage /bin/false\nblacklist usb-storage" >> "$BL"
+  depmod -a
+fi
+echo "done"
+
+# 6. Review chrony run user (informational)
+echo -n "6) Confirm chronyd runs as non-root… "
+if grep -Eq '^OPTIONS=.*-u chrony' /usr/lib/systemd/system/chronyd.service; then
+  echo "OK"
+else
+  echo "WARNING: chronyd may run as root"
+fi
+
+echo
+echo "Medium-risk remediation complete.  Please re-test Citrix VDA functionality."


### PR DESCRIPTION
Firewall Ports (ICA, Registration, LDAP/FAS)

        Citrix documentation clearly states that for VDA registration and ICA traffic you must allow:

        TCP/UDP 1494, 2598 for ICA payload

        TCP 80, 443 for VDA registration with the Delivery Controller

        TCP/UDP 389, 636 if you’re using FAS or LDAP backend
See the “Required VDA Firewall Ports” section in the Citrix Docs: CTX227428 .

SELinux and Citrix VDA

    Citrix ships an RPM with its VDA installer that includes an SELinux policy module. Until that’s installed, SELinux must be in Permissive mode or the VDA will be blocked.
    See “Citrix Linux VDA and SELinux” in CTX269560 .

PAM Ordering for FAS/SSSD

    The Citrix FAS integration guide shows that pam_sss.so forward_pass needs to be the first line in your system-auth stack so certificate‐based login happens before any faillock or complexity checks.
    See the “Configure PAM for FAS” section in the FAS Deployment Guide CTX231864 .

USB Redirection

    To enable USB redirection the usb-storage module must not be blacklisted, or you must explicitly allow it in your policy.
    See CTX215541 “USB Redirection on Linux VDA” .

    If you follow the exact port, SELinux, and PAM ordering guidelines in these Citrix articles, you’ll be in full compliance with both the CIS Benchmark and the Citrix VDA requirements.